### PR TITLE
Updated the tool versions and links

### DIFF
--- a/2020/tools.md
+++ b/2020/tools.md
@@ -6,48 +6,54 @@ tools:
 
 - name: Pre-Processor (Benchmark Scrambler)
   repo: https://github.com/SMT-COMP/scrambler
-  sources:
+  sources: https://github.com/SMT-COMP/scrambler/archive/smtcomp2020.tar.gz
   release:
   tracks:
     - name: track_single_query
-      starexec: SMT-COMP 2020 Non-Incremental Scrambler
+      starexec: SMT-COMP 2020 Single-Query Scrambler
       starexecid: 611
-      release:
+      release: https://github.com/SMT-COMP/scrambler/releases/download/smtcomp2020/SMT-COMP.2020.Single.Query.Scrambler.tar.xz
     - name: track_incremental
       starexec: SMT-COMP 2020 Incremental Scrambler
       starexecid: 609
-      release:
+      release: https://github.com/SMT-COMP/scrambler/releases/download/smtcomp2020/SMT-COMP.2020.Incremental.Scrambler.tar.xz
     - name: track_unsat_core
       starexec: SMT-COMP 2020 Unsat-Core Scrambler
       starexecid: 607
-      release:
+      release: https://github.com/SMT-COMP/scrambler/releases/download/smtcomp2020/SMT-COMP.2020.Unsat-Core.Scrambler.tar.xz
     - name: track_model_validation
       starexec: SMT-COMP 2020 Model-Validation Scrambler
       starexecid: 610
-      release:
+      release: https://github.com/SMT-COMP/scrambler/releases/download/smtcomp2020/SMT-COMP.2020.Model-Validation.Scrambler.tar.xz
 
 - name: Post-Processor
   repo: https://github.com/SMT-COMP/postprocessors
-  sources:
+  sources: https://github.com/SMT-COMP/postprocessors/archive/smtcomp2020.tar.gz
   tracks:
     - name: track_single_query
-      starexec: SMT-COMP 2020 Non-Incremental
-      starexecid: 616
-      release:
+      starexec: SMT-COMP 2020 Single Query 2020 05 27
+      starexecid: 632
+      release: https://github.com/SMT-COMP/postprocessors/releases/download/smtcomp2020/SMT-COMP-2020-single-query-post-processor.tar.xz
     - name: track_incremental
       starexec: SMT-COMP 2020 Incremental
       starexecid: 615
-      release:
+      release: https://github.com/SMT-COMP/postprocessors/releases/download/smtcomp2020/SMT-COMP-2020-incremental-post-processor.tar.xz
     - name: track_unsat_core
-      starexec: SMT-COMP 2020 Unsat-Core
-      starexecid: 613
-      release:
+      starexec: SMT-COMP 2020 Unsat-Core 2020 06 12
+      starexecid: 647
+      release: https://github.com/SMT-COMP/postprocessors/releases/download/smtcomp2020/SMT-COMP-2020-unsat-core-postprocessor.tar.xz
     - name: track_model_validation
       starexec: SMT-COMP 2020 Model-Validation
-      starexecid: 614
-      release:
+      starexecid: 631
+      release: https://github.com/SMT-COMP/postprocessors/releases/download/smtcomp2020/SMT-COMP-2020-model-validation-post-processor.tar.xz
 
 - name: Trace executor
   repo: https://github.com/SMT-COMP/trace-executor
+  sources: https://github.com/SMT-COMP/trace-executor/archive/smtcomp2020.tar.gz
+  release: https://github.com/SMT-COMP/trace-executor/releases/download/smtcomp2020/SMT-COMP-2020-trace-executor.tar.xz
+  wrapped: https://www.starexec.org/starexec/secure/explore/spaces.jsp?id=414650
+
+- name: Competition scripts
+  repo: https://github.com/SMT-COMP/smt-comp
 
 ---

--- a/2020/tools.md
+++ b/2020/tools.md
@@ -55,5 +55,7 @@ tools:
 
 - name: Competition scripts
   repo: https://github.com/SMT-COMP/smt-comp
+  sources: https://github.com/SMT-COMP/smt-comp/archive/smtcomp2020.tar.gz
+  tag: https://github.com/SMT-COMP/smt-comp/releases/tag/smtcomp2020
 
 ---

--- a/_layouts/tools.html
+++ b/_layouts/tools.html
@@ -18,13 +18,14 @@ layout: default
 
 <a href="{{ tool.repo }}"><b>GitHub Repository</b></a><br/>
 {%- if tool.sources -%}
-  <a href="{{ tool.sources }}"><b>Sources</b></a>
+<a href="{{ tool.sources }}"><b>Sources</b></a><br/>
   {%- if tool.release -%}
-    <br/>
-    <a href="{{ tool.release }}"><b>Binary</b></a>
+    <a href="{{ tool.release }}"><b>Binary</b></a><br/>
   {%- endif -%}
 {%- endif -%}
-
+{%- if tool.tag -%}
+<a href="{{ tool.tag }}"><b>Tag</b></a><br/>
+{%- endif -%}
 
   {% if tool.tracks %}
 <h4>SMT-COMP {{ page.year }} Releases</h4>


### PR DESCRIPTION
This PR gives the tags to the sources of the tools used in smt-comp 2020.  In addition, it fixes the names and ids of the processors used in the final run in StarExec.