### PR TITLE
Sysdescr paths

### DIFF
--- a/_layouts/participant.html
+++ b/_layouts/participant.html
@@ -10,7 +10,24 @@ located in year/system-description/.
 {%- if page.sysDescrUrl contains "://" -%}
     {%- assign sysDescrUrl = page.sysDescrUrl -%}
 {%- else -%}
-    {%- assign sysDescrUrl = "../system-descriptions/" | append: page.sysDescrUrl -%}
+
+    {%- comment -%}
+    This is a trick from
+    https://maedi.com/code/jekyll-check-if-string-number/ to figure out
+    if string represents a number.
+    {%- endcomment -%}
+
+    {%- assign toolYear = page.name | slice: 0, 4 -%}
+    {%- assign addition = toolYear | plus: 0 %}
+    {% capture addition %}{{addition}}{% endcapture %}
+    {% if toolYear != addition %}
+        {% assign toolYear = page.year %}
+    {%- endif -%}
+
+    {%- assign sysDescrUrl = "../../"
+        |append: toolYear
+        |append: "/system-descriptions/"
+        |append: page.sysDescrUrl -%}
 {%- endif -%}
 
 <h2>{{ page.name }} </h2>

--- a/_layouts/participants.html
+++ b/_layouts/participants.html
@@ -97,7 +97,22 @@ located in year/system-description/.
 {%- if solver.sysDescrUrl contains "://" -%}
     {%- assign sysDescrUrl = solver.sysDescrUrl -%}
 {%- else -%}
-    {%- assign sysDescrUrl = "system-descriptions/" | append: solver.sysDescrUrl -%}
+    {%- comment -%}
+    This is a trick from
+    https://maedi.com/code/jekyll-check-if-string-number/ to figure out
+    if string represents a number.
+    {%- endcomment -%}
+
+    {%- assign toolYear = solver.name | slice: 0, 4 -%}
+    {%- assign addition = toolYear | plus: 0 %}
+    {% capture addition %}{{addition}}{% endcapture %}
+    {% if toolYear != addition %}
+        {% assign toolYear = page.year %}
+    {%- endif -%}
+    {%- assign sysDescrUrl = "../../"
+        |append: toolYear
+        |append: "/system-descriptions/"
+        |append: solver.sysDescrUrl -%}
 {%- endif -%}
 <a href="{{ sysDescrUrl }}">{{ solver.sysDescrName }}</a></td>
 {%- endif -%}

--- a/_participants_2020/2018-Boolector_(incremental).md
+++ b/_participants_2020/2018-Boolector_(incremental).md
@@ -12,8 +12,8 @@ derivedTool: ""
 competing: "no"
 seed: ""
 solverHomePage: ""
-sysDescrUrl: ""
-sysDescrName: ""
+sysDescrUrl: "Boolector.pdf"
+sysDescrName: "Boolector at the SMT Competition 2018"
 divisions:
 - name: QF_ABV
   tracks:

--- a/_participants_2020/2018-CVC4.md
+++ b/_participants_2020/2018-CVC4.md
@@ -12,8 +12,8 @@ derivedTool: ""
 competing: "no"
 seed: ""
 solverHomePage: ""
-sysDescrUrl: ""
-sysDescrName: ""
+sysDescrUrl: "CVC4.pdf"
+sysDescrName: "CVC4 at the SMT Competition 2018"
 divisions:
 - name: ABVFP
   tracks:

--- a/_participants_2020/2018-CVC4_(incremental).md
+++ b/_participants_2020/2018-CVC4_(incremental).md
@@ -12,8 +12,8 @@ derivedTool: ""
 competing: "no"
 seed: ""
 solverHomePage: ""
-sysDescrUrl: ""
-sysDescrName: ""
+sysDescrUrl: "CVC4.pdf"
+sysDescrName: "CVC4 at the SMT Competition 2018"
 divisions:
 - name: ANIA
   tracks:

--- a/_participants_2020/2018-CVC4_(unsat_core).md
+++ b/_participants_2020/2018-CVC4_(unsat_core).md
@@ -12,8 +12,8 @@ derivedTool: ""
 competing: "no"
 seed: ""
 solverHomePage: ""
-sysDescrUrl: ""
-sysDescrName: ""
+sysDescrUrl: "CVC4.pdf"
+sysDescrName: "CVC4 at the SMT Competition 2018"
 divisions:
 - name: AUFLIA
   tracks:

--- a/_participants_2020/2018-SMTRAT-Rat.md
+++ b/_participants_2020/2018-SMTRAT-Rat.md
@@ -12,8 +12,8 @@ derivedTool: ""
 competing: "no"
 seed: ""
 solverHomePage: ""
-sysDescrUrl: ""
-sysDescrName: ""
+sysDescrUrl: "SMTRAT.pdf"
+sysDescrName: "SMT-RAT 2.2"
 divisions:
 - name: QF_NIRA
   tracks:

--- a/_participants_2020/2019-Boolector.md
+++ b/_participants_2020/2019-Boolector.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: "https://boolector.github.io"
 sysDescrUrl: "boolector.pdf"
-sysDescrName: "Boolector"
+sysDescrName: "Boolector at the SMT Competition 2019"
 divisions:
 - name: QF_ABV
   tracks:

--- a/_participants_2020/2019-CVC4-inc.md
+++ b/_participants_2020/2019-CVC4-inc.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: "http://cvc4.cs.stanford.edu"
 sysDescrUrl: "cvc4.pdf"
-sysDescrName: "CVC4"
+sysDescrName: "CVC4 at the SMT Competition 2019"
 divisions:
 - name: ABVFP
   tracks:

--- a/_participants_2020/2019-CVC4-uc.md
+++ b/_participants_2020/2019-CVC4-uc.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: "http://cvc4.cs.stanford.edu"
 sysDescrUrl: "cvc4.pdf"
-sysDescrName: "CVC4"
+sysDescrName: "CVC4 at the SMT Competition 2019"
 divisions:
 - name: AUFNIRA
   tracks:

--- a/_participants_2020/2019-CVC4.md
+++ b/_participants_2020/2019-CVC4.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: "http://cvc4.cs.stanford.edu"
 sysDescrUrl: "cvc4.pdf"
-sysDescrName: "CVC4"
+sysDescrName: "CVC4 at the SMT Competition 2019"
 divisions:
 - name: QF_ANIA
   tracks:

--- a/_participants_2020/2019-MathSAT-default.md
+++ b/_participants_2020/2019-MathSAT-default.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: ""
 sysDescrUrl: "mathsat5.pdf"
-sysDescrName: "MathSAT5"
+sysDescrName: "MathSAT5 (Nonlinear) at the SMT Competition 2019"
 divisions:
 - name: QF_AUFNIA
   tracks:

--- a/_participants_2020/2019-MathSAT-na-ext.md
+++ b/_participants_2020/2019-MathSAT-na-ext.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: ""
 sysDescrUrl: "mathsat5.pdf"
-sysDescrName: "MathSAT5"
+sysDescrName: "MathSAT5 (Nonlinear) at the SMT Competition 2019"
 divisions:
 - name: QF_AUFBVNIA
   tracks:

--- a/_participants_2020/2019-Poolector.md
+++ b/_participants_2020/2019-Poolector.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: "https://boolector.github.io"
 sysDescrUrl: "boolector.pdf"
-sysDescrName: "Boolector"
+sysDescrName: "Boolector at the SMT Competition 2019"
 divisions:
 - name: QF_BV
   tracks:

--- a/_participants_2020/2019-SPASS-SATT.md
+++ b/_participants_2020/2019-SPASS-SATT.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: "https://www.spass-prover.org/"
 sysDescrUrl: "SPASS-SATT.pdf"
-sysDescrName: "SPASS-SATT"
+sysDescrName: "SPASS-SATT v1.1"
 divisions:
 - name: QF_LRA
   tracks:

--- a/_participants_2020/2019-Vampire.md
+++ b/_participants_2020/2019-Vampire.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: "https://vprover.github.io"
 sysDescrUrl: "vampire.pdf"
-sysDescrName: "Vampire"
+sysDescrName: "Vampire 4.4-SMT System Description"
 divisions:
 - name: UFDTNIA
   tracks:

--- a/_participants_2020/2019-Yices_2.6.2.md
+++ b/_participants_2020/2019-Yices_2.6.2.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: "http://yices.csl.sri.com"
 sysDescrUrl: "yices.pdf"
-sysDescrName: "Yices"
+sysDescrName: "Yices 2 in SMT-COMP 2019"
 divisions:
 - name: QF_ALIA
   tracks:

--- a/_participants_2020/2019-Yices_2.6.2_Incremental.md
+++ b/_participants_2020/2019-Yices_2.6.2_Incremental.md
@@ -13,7 +13,7 @@ competing: "no"
 seed: ""
 solverHomePage: "http://yices.csl.sri.com"
 sysDescrUrl: "yices.pdf"
-sysDescrName: "Yices"
+sysDescrName: "Yices 2 in SMT-COMP 2019"
 divisions:
 - name: QF_AUFBV
   tracks:


### PR DESCRIPTION
This PR

 - adds the available tool reports from 2018 and adjusts the names of the tools.
 - introduces a trick that derives the correct tool report subdirectory based on the solver name

The latter is based on a naming convention that has been followed for at least the last few years, where the old tools are prepended with the year.  This year is extracted from the tool name by checking if the first 4 characters constitute a number, and if so, a path is constructed based on the name.  If not, the default year is used that is obtained from the page's `year` field.

The motivation for implementing it this way is that it should be as simple as possible to cut the previous entries from an old `solvers_divisions_final.csv` and plug them into a new year's edition, by simply prepending the tool by it's year where absent.
