### PR TITLE
bitwuzla: Change options for parallel track.

### DIFF
--- a/submissions/bitwuzla_parallel_16.json
+++ b/submissions/bitwuzla_parallel_16.json
@@ -15,6 +15,7 @@
   "system_description": "https://bitwuzla.github.io/data/smtcomp2025/paper.pdf",
   "solver_type": "Standalone",
   "seed": "42",
+  "competitive": false,
   "participations": [
     {
       "tracks": ["Parallel"],

--- a/submissions/bitwuzla_parallel_16.json
+++ b/submissions/bitwuzla_parallel_16.json
@@ -17,29 +17,10 @@
   "seed": "42",
   "participations": [
     {
-      "tracks": ["SingleQuery"],
-      "logics": "^((QF_)?(A)?(UF)?(BV|FP|FPLRA)+)$",
-      "command": ["bin/bitwuzla"]
-    },
-    {
-      "tracks": ["Incremental"],
-      "logics": "^((QF_)?(A)?(UF)?(BV|FP|FPLRA)+)$",
-      "command": ["bin/bitwuzla"]
-    },
-    {
-      "tracks": ["UnsatCore"],
-      "logics": "^((QF_)?(A)?(UF)?(BV|FP|FPLRA)+)$",
-      "command": ["bin/bitwuzla"]
-    },
-    {
-      "tracks": ["ModelValidation"],
-      "logics": "^((QF_)?(A)?(UF)?(BV|FP|FPLRA)+)$",
-      "command": ["bin/bitwuzla"]
-    },
-    {
       "tracks": ["Parallel"],
       "logics": "^((QF_)?(A)?(UF)?(BV|FP|FPLRA)+)$",
-      "command": ["bin/bitwuzla", "--sat-solver=gimsatul", "-j", "64"]
+      "command": ["bin/bitwuzla", "--sat-solver=gimsatul", "-j", "16"]
     }
   ]
 }
+

--- a/submissions/bitwuzla_parallel_32.json
+++ b/submissions/bitwuzla_parallel_32.json
@@ -15,6 +15,7 @@
   "system_description": "https://bitwuzla.github.io/data/smtcomp2025/paper.pdf",
   "solver_type": "Standalone",
   "seed": "42",
+  "competitive": false,
   "participations": [
     {
       "tracks": ["Parallel"],

--- a/submissions/bitwuzla_parallel_32.json
+++ b/submissions/bitwuzla_parallel_32.json
@@ -17,29 +17,10 @@
   "seed": "42",
   "participations": [
     {
-      "tracks": ["SingleQuery"],
-      "logics": "^((QF_)?(A)?(UF)?(BV|FP|FPLRA)+)$",
-      "command": ["bin/bitwuzla"]
-    },
-    {
-      "tracks": ["Incremental"],
-      "logics": "^((QF_)?(A)?(UF)?(BV|FP|FPLRA)+)$",
-      "command": ["bin/bitwuzla"]
-    },
-    {
-      "tracks": ["UnsatCore"],
-      "logics": "^((QF_)?(A)?(UF)?(BV|FP|FPLRA)+)$",
-      "command": ["bin/bitwuzla"]
-    },
-    {
-      "tracks": ["ModelValidation"],
-      "logics": "^((QF_)?(A)?(UF)?(BV|FP|FPLRA)+)$",
-      "command": ["bin/bitwuzla"]
-    },
-    {
       "tracks": ["Parallel"],
       "logics": "^((QF_)?(A)?(UF)?(BV|FP|FPLRA)+)$",
-      "command": ["bin/bitwuzla", "--sat-solver=gimsatul", "-j", "64"]
+      "command": ["bin/bitwuzla", "--sat-solver=gimsatul", "-j", "32"]
     }
   ]
 }
+


### PR DESCRIPTION
Add additional configurations for lower CPU core counts.

@martinjonas The additional configurations for the speed-up experiments should be separate submission files, right?