### PR TITLE
bv_decide 2026 submission

### DIFF
--- a/submissions/bv_decide-nokernel.json
+++ b/submissions/bv_decide-nokernel.json
@@ -1,0 +1,47 @@
+{
+    "name": "bv_decide-nokernel",
+    "contributors": [
+        "Henrik Böving",
+        "Siddharth Bhat",
+        "Alex Keizer",
+        "Luisa Cicolini",
+        "Leon Frenot",
+        "Abdalrhman Mohamed",
+        "Léo Stefanesco",
+        "Harun Khan",
+        "Josh Clune",
+        "Clark Barrett",
+        "Tobias Grosser"
+    ],
+    "contacts": [
+        "Henrik Böving <henrik@lean-fro.org>",
+        "Siddharth Bhat <siddharth.bhat@cl.cam.ac.uk>",
+        "Luisa Cicolini <luisa.cicolini@cl.cam.ac.uk>",
+        "Abdalrhman Mohamed <abdal@stanford.edu>"
+    ],
+    "archive": {
+        "url": "https://zenodo.org/records/20369518/files/bv_decide_2026.zip?download=1"
+    },
+    "command": ["leanwuzla.sh"],
+    "website": "https://github.com/hargoniX/Leanwuzla",
+    "system_description": "https://github.com/hargoniX/Leanwuzla/releases/download/smtcomp2026/bv_decide.pdf",
+    "solver_type": "derived",
+    "seed": 42,
+    "participations": [
+        {
+            "tracks": ["SingleQuery"],
+            "logics": "QF_BV",
+            "command": [
+                "leanwuzla.sh",
+                "--disableKernel",
+                "--disableEmbeddedConstraintSubst",
+                "--expthreshold=32768",
+                "--acnf",
+                "--timeout=1200",
+                "--maxSteps=100000000",
+                "--maxHeartbeats=200000000",
+                "--maxRecDepth=1048576"
+            ]
+        }
+    ]
+}

--- a/submissions/bv_decide-nokernel.json
+++ b/submissions/bv_decide-nokernel.json
@@ -25,7 +25,7 @@
     "command": ["leanwuzla.sh"],
     "website": "https://github.com/hargoniX/Leanwuzla",
     "system_description": "https://github.com/hargoniX/Leanwuzla/releases/download/smtcomp2026/bv_decide.pdf",
-    "solver_type": "derived",
+    "solver_type": "Standalone",
     "seed": 42,
     "participations": [
         {

--- a/submissions/bv_decide-nokernel.json
+++ b/submissions/bv_decide-nokernel.json
@@ -20,7 +20,7 @@
         "Abdalrhman Mohamed <abdal@stanford.edu>"
     ],
     "archive": {
-        "url": "https://zenodo.org/records/20369518/files/bv_decide_2026.zip?download=1"
+        "url": "https://zenodo.org/records/20600607/files/bv_decide_2026.zip?download=1"
     },
     "command": ["leanwuzla.sh"],
     "website": "https://github.com/hargoniX/Leanwuzla",
@@ -30,6 +30,21 @@
     "participations": [
         {
             "tracks": ["SingleQuery"],
+            "logics": "QF_BV",
+            "command": [
+                "leanwuzla.sh",
+                "--disableKernel",
+                "--disableEmbeddedConstraintSubst",
+                "--expthreshold=32768",
+                "--acnf",
+                "--timeout=1200",
+                "--maxSteps=100000000",
+                "--maxHeartbeats=200000000",
+                "--maxRecDepth=1048576"
+            ]
+        },
+        {
+            "tracks": ["ModelValidation"],
             "logics": "QF_BV",
             "command": [
                 "leanwuzla.sh",

--- a/submissions/bv_decide.json
+++ b/submissions/bv_decide.json
@@ -1,0 +1,47 @@
+{
+    "name": "bv_decide",
+    "contributors": [
+        "Henrik Böving",
+        "Siddharth Bhat",
+        "Alex Keizer",
+        "Luisa Cicolini",
+        "Leon Frenot",
+        "Abdalrhman Mohamed",
+        "Léo Stefanesco",
+        "Harun Khan",
+        "Josh Clune",
+        "Clark Barrett",
+        "Tobias Grosser"
+    ],
+    "contacts": [
+        "Henrik Böving <henrik@lean-fro.org>",
+        "Siddharth Bhat <siddharth.bhat@cl.cam.ac.uk>",
+        "Luisa Cicolini <luisa.cicolini@cl.cam.ac.uk>",
+        "Abdalrhman Mohamed <abdal@stanford.edu>"
+    ],
+    "archive": {
+        "url": "https://zenodo.org/records/20369518/files/bv_decide_2026.zip?download=1"
+    },
+    "command": ["leanwuzla.sh"],
+    "website": "https://github.com/hargoniX/Leanwuzla",
+    "system_description": "https://github.com/hargoniX/Leanwuzla/releases/download/smtcomp2026/bv_decide.pdf",
+    "solver_type": "Standalone",
+    "seed": 42,
+    "participations": [
+        {
+            "tracks": ["SingleQuery"],
+            "logics": "QF_BV",
+            "command": [
+                "leanwuzla.sh",
+                "--disableEmbeddedConstraintSubst",
+                "--expthreshold=32768",
+                "--acnf",
+                "--timeout=1200",
+                "--maxSteps=100000000",
+                "--maxHeartbeats=200000000",
+                "--maxRecDepth=1048576"
+            ]
+        }
+    ]
+}
+

--- a/submissions/bv_decide.json
+++ b/submissions/bv_decide.json
@@ -20,7 +20,7 @@
         "Abdalrhman Mohamed <abdal@stanford.edu>"
     ],
     "archive": {
-        "url": "https://zenodo.org/records/20369518/files/bv_decide_2026.zip?download=1"
+        "url": "https://zenodo.org/records/20600607/files/bv_decide_2026.zip?download=1"
     },
     "command": ["leanwuzla.sh"],
     "website": "https://github.com/hargoniX/Leanwuzla",
@@ -30,6 +30,20 @@
     "participations": [
         {
             "tracks": ["SingleQuery"],
+            "logics": "QF_BV",
+            "command": [
+                "leanwuzla.sh",
+                "--disableEmbeddedConstraintSubst",
+                "--expthreshold=32768",
+                "--acnf",
+                "--timeout=1200",
+                "--maxSteps=100000000",
+                "--maxHeartbeats=200000000",
+                "--maxRecDepth=1048576"
+            ]
+        },
+        {
+            "tracks": ["ModelValidation"],
             "logics": "QF_BV",
             "command": [
                 "leanwuzla.sh",


### PR DESCRIPTION
This PR adds bv_decide as a competing solver in SMT-COMP 2026. Like last year we submit two configurations:
- With kernel checking enabled (fully verified, end-to-end),
- With kernel checking disabled (higher performance, partially verified).
