### PR TITLE
Roole 2026 submission

### DIFF
--- a/submissions/roole.json
+++ b/submissions/roole.json
@@ -5,12 +5,13 @@
         "Armin Biere"
     ],
     "contacts": ["Jan Onderka <onderka@cs.uni-freiburg.net>"],
+    "final": true,
     "archive": {
-        "url": "https://github.com/onderjan/roole-smt-comp/raw/89d408abd6b8b5b4d19552f79f501a6d309158b7/relics/roole.tar.gz",
-        "h": { "sha256": "44c6b6119c0c521b3a6ada111601f7ae014827e564626f5558ec0fbad40a7b55" }
+        "url": "https://zenodo.org/records/20584485/files/roole.tar.gz?download=1",
+        "h": { "sha256": "1390a15c4579accf6274ffb293ad50887289bccd20e4b8587e6b85ff76f9ff29" }
     },
     "website": "https://github.com/onderjan/roole",
-    "system_description": "https://github.com/onderjan/roole-smt-comp/raw/89d408abd6b8b5b4d19552f79f501a6d309158b7/relics/roole.pdf",
+    "system_description": "https://zenodo.org/records/20584485/files/roole.pdf?download=1",
     "command": ["roole", "--silent"],
     "solver_type": "Standalone",
     "seed": "22961",

--- a/submissions/roole.json
+++ b/submissions/roole.json
@@ -6,12 +6,12 @@
     ],
     "contacts": ["Jan Onderka <onderka@cs.uni-freiburg.net>"],
     "archive": {
-        "url": "https://github.com/onderjan/roole-smt-comp/raw/34460428ec7e43c278e8effdce74da49b90a613f/relics/roole.tar.gz",
+        "url": "https://github.com/onderjan/roole-smt-comp/raw/89d408abd6b8b5b4d19552f79f501a6d309158b7/relics/roole.tar.gz",
         "h": { "sha256": "44c6b6119c0c521b3a6ada111601f7ae014827e564626f5558ec0fbad40a7b55" }
     },
     "website": "https://github.com/onderjan/roole",
-    "system_description": "https://github.com/onderjan/roole-smt-comp/raw/34460428ec7e43c278e8effdce74da49b90a613f/relics/roole.pdf",
-    "command": ["roole"],
+    "system_description": "https://github.com/onderjan/roole-smt-comp/raw/89d408abd6b8b5b4d19552f79f501a6d309158b7/relics/roole.pdf",
+    "command": ["roole", "--silent"],
     "solver_type": "Standalone",
     "seed": "22961",
     "participations": [
@@ -19,7 +19,8 @@
             "tracks": ["SingleQuery"],
             "logics": "QF_BV",
             "command": [
-                "roole"
+                "roole",
+                "--silent"
             ]
         }
     ]

--- a/submissions/roole.json
+++ b/submissions/roole.json
@@ -1,0 +1,26 @@
+{
+    "name": "Roole",
+    "contributors": [
+        { "name": "Jan Onderka", "website": "http://onderjan.net/" },
+        "Armin Biere"
+    ],
+    "contacts": ["Jan Onderka <onderka@cs.uni-freiburg.net>"],
+    "archive": {
+        "url": "https://github.com/onderjan/roole-smt-comp/raw/34460428ec7e43c278e8effdce74da49b90a613f/relics/roole.tar.gz",
+        "h": { "sha256": "44c6b6119c0c521b3a6ada111601f7ae014827e564626f5558ec0fbad40a7b55" }
+    },
+    "website": "https://github.com/onderjan/roole",
+    "system_description": "https://github.com/onderjan/roole-smt-comp/raw/34460428ec7e43c278e8effdce74da49b90a613f/relics/roole.pdf",
+    "command": ["roole"],
+    "solver_type": "Standalone",
+    "seed": "22961",
+    "participations": [
+        {
+            "tracks": ["SingleQuery"],
+            "logics": "QF_BV",
+            "command": [
+                "roole",
+            ]
+        }
+    ]
+}

--- a/submissions/roole.json
+++ b/submissions/roole.json
@@ -19,7 +19,7 @@
             "tracks": ["SingleQuery"],
             "logics": "QF_BV",
             "command": [
-                "roole",
+                "roole"
             ]
         }
     ]


### PR DESCRIPTION
This PR adds Roole as a QF_BV solver for SMT-COMP 2026.

This is a new solver with its own SMT-LIB2 parser, so despite my best efforts, I anticipate some possible problems when fed by the the executor.