### PR TITLE
Bitwuzla fixed

### DIFF
--- a/submissions/bitwuzla-fixed.json
+++ b/submissions/bitwuzla-fixed.json
@@ -3,7 +3,7 @@
   "contributors": ["Aina Niemetz", "Mathias Preiner"],
   "contacts": ["Mathias Preiner <preiner@cs.stanford.edu>"],
   "final": true,
-
+  "competitive": false,
   "archive": {
     "url": "https://zenodo.org/records/21445437/files/bitwuzla-submission-smtcomp-2026.zip?download=1",
     "h": {"sha256": "9ff83e5a77d5af392386341e462c5fb2d420d0e9e27ab22900b02026d2871745"}

--- a/submissions/bitwuzla-fixed.json
+++ b/submissions/bitwuzla-fixed.json
@@ -14,7 +14,7 @@
   "website": "https://bitwuzla.github.io",
   "system_description": "https://bitwuzla.github.io/data/smtcomp2026/paper.pdf",
   "solver_type": "Standalone",
-  "seed": "42",
+  "seed": "0",
   "participations": [
     {
       "tracks": ["SingleQuery"],

--- a/web/content/cloud_track/call-for-solvers.txt
+++ b/web/content/cloud_track/call-for-solvers.txt
@@ -11,9 +11,9 @@ k
 
 
 We invite registration of solvers for the cloud track at SMT-COMP 2026.
-The cloud track is run separately from all other tracks with its own procedur es, 
-infrastructure, deadlines, and result announcement. Please read the related      
-instructions on the SMT-COMP website [1].  
+The cloud track is run separately from all other tracks with its own procedur es,
+infrastructure, deadlines, and result announcement. Please read the related
+instructions on the SMT-COMP website [1].
 
 The submission deadline for (first versions of) cloud solvers is
 
@@ -25,8 +25,8 @@ submitted solvers may be updated via the pull request until
 
     ***Aug 22, 2026 AoE***
 
-The cloud track is hosted by AWS and uses a different infrastructure than 
-all other tracks. 
+The cloud track is hosted by AWS and uses a different infrastructure than
+all other tracks.
 
 The organizing team
 
@@ -34,7 +34,7 @@ Dominik Winterer (chair) - University of Manchester, United Kingdom
 Martin Jonáš - Masaryk University, Czechia
 Tomáš Kolárik - Università della Svizzera italiana, Switzerland
 
-Contacts for inquiries about the cloud track:   
+Contacts for inquiries about the cloud track:
 Cayden Codel — crcodel@amazon.com
 Robert Jones — rbtjones@amazon.com
 

--- a/web/content/cloud_track/index.md
+++ b/web/content/cloud_track/index.md
@@ -2,45 +2,52 @@
 
 The cloud track of SMT-COMP '26 is run separately from all other tracks with its own procedures, infrastructure, deadlines, and result announcement.
 
-### Key dates  
+### Key dates
+
 - **Aug 8, 2026**— preliminary call for solvers (should compile & pass basic tests).
 - **Aug 22, 2026** — final call for solvers
 
 All deadlines are 11:59 PM AoE (Anywhere on Earth).
 
-### Submission Instructions 
+### Submission Instructions
 
-#### Infrastructure 
-[`aws-samples/aws-batch-comp-infrastructure-sample`](https://github.com/aws-samples/aws-batch-comp-infrastructure-sample) on the **`mainline-2026`** (default). 
+#### Infrastructure
 
-*Each submission needs to be prepared according based on this repository.*
+[`aws-samples/aws-batch-comp-infrastructure-sample`](https://github.com/aws-samples/aws-batch-comp-infrastructure-sample) on the **`mainline-2026`** (default).
+
+_Each submission needs to be prepared according based on this repository._
 
 #### What to Submit
+
 In your solver's repo, add a top-level **`aws-build/`** directory containing:
+
 1. **Dockerfile** — must extend the provided base Dockerfile; build solver **from source**; dependencies only via standard package managers (e.g. `apt-get`); `git clone` allowed only for open-source repos.
 2. **`solver_cmd.py`** — returns the command-line args used to invoke your solver.
 
 Repo (including source) must stay **open source** at least through the final deadline.
 
 #### Solver Requirements
+
 - Return exit codes: **10 = SAT, 20 = UNSAT, 0 = UNKNOWN**, anything else = error.
-- (Distributed only) Your Dockerfile should compile solvers for both the leader and the worker. Note that the solver harness invokes one machine (the leader) per problem; the leader is responsible for driving workers over SSH/MPI using the provided list of IP addresses. 
+- (Distributed only) Your Dockerfile should compile solvers for both the leader and the worker. Note that the solver harness invokes one machine (the leader) per problem; the leader is responsible for driving workers over SSH/MPI using the provided list of IP addresses.
 - The provided solver harness downloads benchmarks previously uploaded to S3 (`.cnf`/`.smt2`, compressed OK) and runs until timeout/memout.
 
-
 #### Steps
+
 1. Fix exit codes.
 2. Write Dockerfile + `solver_cmd.py`.
 3. Add YAML config describing the solver.
 4. Build/test locally with `satcomp.py` (recommended before submitting).
-5. *(Optional, encouraged)* Test on AWS — you cover costs, likely under $100.
+5. _(Optional, encouraged)_ Test on AWS — you cover costs, likely under $100.
 6. Submit repo link (or tarball) with `aws-build/`.
 
 #### Timeouts & Specs
+
 - Cloud track timeout: **200s** (recommended, mirrors SAT-COMP).
 - Parallel track timeout: **1000s**.
 - 2024 hardware reference: 100x m4.4xlarge (16 vCPU / 8 core, 64GB RAM each).
 
 ### Contacts
+
 - Cayden Codel — crcodel@amazon.com
 - Robert Jones — rbtjones@amazon.com

--- a/web/content/news/2026-05-16-final-call.md
+++ b/web/content/news/2026-05-16-final-call.md
@@ -1,21 +1,18 @@
 ---
 layout: single
 author:
-title: Final Call for Solvers  
+title: Final Call for Solvers
 date: 2026-05-16T00:00:00+01:00
 ---
 
- 21st International Satisfiability Modulo Theories Competition
-                        (SMT-COMP'26)
-                    FINAL CALL FOR SOLVERS
+21st International Satisfiability Modulo Theories Competition
+(SMT-COMP'26)
+FINAL CALL FOR SOLVERS
 
                         July 24–25, 2026
                         Lisbon, Portugal
 
-
-
 We invite registration of solvers for SMT-COMP 2026.
-
 
 Solvers are entered into the competition via a pull request to the SMT-COMP
 GitHub repository at:
@@ -71,7 +68,7 @@ These can be specified as part of the solver submission and changed until the
 deadline for the final solver. The default configuration is used for all other
 tracks.
 
-Please see the competition rules for further details. Do not hesitate contacting us 
+Please see the competition rules for further details. Do not hesitate contacting us
 if you have any questions or comments.
 
 Sincerely,
@@ -83,6 +80,7 @@ Martin Jonáš - Masaryk University, Czechia
 Tomáš Kolárik - Università della Svizzera italiana, Switzerland
 
 ## COMMUNICATION:
+
 The competition website is at
 https://smt-comp.github.io/2026/
 
@@ -91,4 +89,3 @@ https://github.com/SMT-COMP/smt-comp.github.io
 
 Public email regarding the competition may be sent to
 smt-announce@googlegroups.com
-


### PR DESCRIPTION
Simple administrative changes for the fixed Bitwuzla submission
- mark as non-competing,
- set seed to 0, as the competition seed has already been fixed.